### PR TITLE
Update libp2p link

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@ Although they are slightly outdated, they capture the essence of fc00 very well.
     <li>IPTunnel</li>
   </ul></li>
   <li>Go implementation of FCP CryptoAuth and Switch</li>
-  <li>Integration with <a href="https://github.com/ipfs/specs/tree/master/libp2p">libp2p</a></li>
+  <li>Integration with <a href="https://github.com/libp2p">libp2p</a></li>
 </ul>
 
 <!-- Piwik -->


### PR DESCRIPTION
The link was outdated, and points to a new reference location.